### PR TITLE
Call didChangeRevealedStateForViewController after animation completes.

### DIFF
--- a/JTRevealSidebarV2/UIViewController+JTRevealSidebarV2.m
+++ b/JTRevealSidebarV2/UIViewController+JTRevealSidebarV2.m
@@ -123,8 +123,11 @@ static char *revealedStateKey;
 }
 
 - (void)animationDidStop:(NSString *)animationID finished:(NSNumber *)finished context:(void *)context {
-    UIView *view = [self.view.superview viewWithTag:(int)context];
-    [view removeFromSuperview];
+    if ([animationID isEqualToString:@"hideSidebarView"]) {
+        // Remove the sidebar view after the sidebar closes.
+        UIView *view = [self.view.superview viewWithTag:(int)context];
+        [view removeFromSuperview];
+    }
     
     // notify delegate for controller changed state
     id <JTRevealSidebarV2Delegate> delegate = 

--- a/JTRevealSidebarV2/UIViewController+JTRevealSidebarV2.m
+++ b/JTRevealSidebarV2/UIViewController+JTRevealSidebarV2.m
@@ -70,11 +70,6 @@ static char *revealedStateKey;
         default:
             break;
     }
-
-    // notify delegate for controller will change state
-    if ([delegate respondsToSelector:@selector(didChangeRevealedStateForViewController:)]) {
-        [delegate didChangeRevealedStateForViewController:self];
-    }
 }
 
 - (JTRevealedState)revealedState {
@@ -130,6 +125,13 @@ static char *revealedStateKey;
 - (void)animationDidStop:(NSString *)animationID finished:(NSNumber *)finished context:(void *)context {
     UIView *view = [self.view.superview viewWithTag:(int)context];
     [view removeFromSuperview];
+    
+    // notify delegate for controller changed state
+    id <JTRevealSidebarV2Delegate> delegate = 
+        [self selectedViewController].navigationItem.revealSidebarDelegate;
+    if ([delegate respondsToSelector:@selector(didChangeRevealedStateForViewController:)]) {
+        [delegate didChangeRevealedStateForViewController:self];
+    }
 }
 
 - (void)revealLeftSidebar:(BOOL)showLeftSidebar {
@@ -157,11 +159,10 @@ static char *revealedStateKey;
 //        self.view.transform = CGAffineTransformTranslate([self baseTransform], -width, 0);
         
         self.view.frame = (CGRect){CGPointZero, self.view.frame.size};
-
-
-        [UIView setAnimationDidStopSelector:@selector(animationDidStop:finished:context:)];
-        [UIView setAnimationDelegate:self];
     }
+    
+    [UIView setAnimationDidStopSelector:@selector(animationDidStop:finished:context:)];
+    [UIView setAnimationDelegate:self];
     
     NSLog(@"%@", NSStringFromCGAffineTransform(self.view.transform));
 
@@ -192,11 +193,11 @@ static char *revealedStateKey;
     } else {
         [UIView beginAnimations:@"hideSidebarView" context:(void *)SIDEBAR_VIEW_TAG];
 //        self.view.transform = CGAffineTransformTranslate([self baseTransform], width, 0);
-        self.view.frame = (CGRect){CGPointZero, self.view.frame.size};
-        
-        [UIView setAnimationDidStopSelector:@selector(animationDidStop:finished:context:)];
-        [UIView setAnimationDelegate:self];
+        self.view.frame = (CGRect){CGPointZero, self.view.frame.size};        
     }
+    
+    [UIView setAnimationDidStopSelector:@selector(animationDidStop:finished:context:)];
+    [UIView setAnimationDelegate:self];
 
     NSLog(@"%@", NSStringFromCGAffineTransform(self.view.transform));
     


### PR DESCRIPTION
I noticed didChangeRevealedStateForViewController gets called right after willChangeRevealedStateForViewController (before the animation starts).  Should it be called after the animation completes?  If so, this fix seems to work.

Thanks for publishing this btw!
