### PR TITLE
Fix hideSidebarView to reposition view correctly

### DIFF
--- a/JTRevealSidebarV2/UIViewController+JTRevealSidebarV2.m
+++ b/JTRevealSidebarV2/UIViewController+JTRevealSidebarV2.m
@@ -164,7 +164,7 @@ static char *revealedStateKey;
         [UIView beginAnimations:@"hideSidebarView" context:(void *)SIDEBAR_VIEW_TAG];
 //        self.view.transform = CGAffineTransformTranslate([self baseTransform], -width, 0);
         
-        self.view.frame = (CGRect){CGPointZero, self.view.frame.size};
+        self.view.frame = CGRectOffset(self.view.frame, -width, 0);
     }
     
     [UIView setAnimationDidStopSelector:@selector(animationDidStop2:finished:context:)];
@@ -199,7 +199,7 @@ static char *revealedStateKey;
     } else {
         [UIView beginAnimations:@"hideSidebarView" context:(void *)SIDEBAR_VIEW_TAG];
 //        self.view.transform = CGAffineTransformTranslate([self baseTransform], width, 0);
-        self.view.frame = (CGRect){CGPointZero, self.view.frame.size};        
+        self.view.frame = CGRectOffset(self.view.frame, width, 0);
     }
     
     [UIView setAnimationDidStopSelector:@selector(animationDidStop2:finished:context:)];


### PR DESCRIPTION
Code initially used (CGRect){CGPointZero, self.view.frame.size} as the point to return the original view to. This assumes that the origin is 0,0 which may not be true if the originating view does not have a navigation controller.

Change transform to offset it by the reverse width amount (for both reveal left and reveal right). This is the correct reverse transform that should be applied to restore the view correctly.
